### PR TITLE
Fixed forbidden characters in protein names

### DIFF
--- a/scripts/reFormatFasta.py
+++ b/scripts/reFormatFasta.py
@@ -3,11 +3,11 @@ import sys
 from collections import deque
 import json
 import yaml
+import re
 
 inFile = sys.argv[1]
 outFile = sys.argv[2]
-TITLE = sys.argv[3]
-#window = int(sys.argv[3])
+TITLE = re.sub("@prime@", "'",sys.argv[3])
 inPTM = sys.argv[4:]
 
 #these are the colors assigned to the PTMs in the order they are presented in.

--- a/snakefile
+++ b/snakefile
@@ -5,6 +5,7 @@ import glob
 import sys
 import requests
 import pandas as pd
+import re
 
 
 #---------------CONFIG--------------------
@@ -98,6 +99,8 @@ for i in ORTHOLOGS:
   name = re.sub("[\(\),]","", name)
   name = re.sub(" /.*$","", name).strip()
   name = re.sub("[/ :]","_", name)
+  name = re.sub("->","-to-", name)
+  name = re.sub("'","prime", name)
   SYMBOLS.append(symbol)
   NAMES.append(name)
   SN_MATCHUPS[i] = (symbol, name)
@@ -170,7 +173,7 @@ rule fastaAnnotate:
   output:
     html=FINAL_ALIGNMENTS+'/{ptm_types}/{ko}__{symbol}__{name}.html'
   params:
-    title=lambda w: FULLNAMES[w.ko]
+    title=lambda w: re.sub("'","@prime@", FULLNAMES[w.ko])
   shell:
     '''
     {PYTHON} scripts/reFormatFasta.py {input.alignment} {output.html} '{params.title}' {input.ptms}


### PR DESCRIPTION
Fixed fastaAnnotate rule to prevent two different characters that were breaking execution:
- `->` replaced with `_to_` in file names
- `'` replaced with `prime` in file names and a workaround added to still accept the protein name with `'` as a rule parameter.
